### PR TITLE
Fix typo in help text for SDRAM command-line argument

### DIFF
--- a/litex/SoC-baremetal/hw/OrangeCrab-bitstream.py
+++ b/litex/SoC-baremetal/hw/OrangeCrab-bitstream.py
@@ -192,7 +192,7 @@ def main():
     parser.add_argument("--device", default="25F",
                         help="ECP5 device (default=25F)")
     parser.add_argument("--sdram-device", default="MT41K64M16",
-                        help="ECP5 device (default=MT41K64M16)")
+                        help="SDRAM device (default=MT41K64M16)")
     parser.add_argument(
         "--update-firmware", default=False, action='store_true',
         help="compile firmware and update existing gateware"

--- a/litex/SoC/OrangeCrab-bitstream.py
+++ b/litex/SoC/OrangeCrab-bitstream.py
@@ -167,7 +167,7 @@ def main():
     parser.add_argument("--device", default="25F",
                         help="ECP5 device (default=25F)")
     parser.add_argument("--sdram-device", default="MT41K64M16",
-                        help="ECP5 device (default=MT41K64M16)")
+                        help="SDRAM device (default=MT41K64M16)")
     args = parser.parse_args()
 
     print(argdict(args))


### PR DESCRIPTION
Just a quick PR to clean up the accidental duplication of an argument's help text.