### PR TITLE
add LiteX toolchain setup instructions

### DIFF
--- a/litex/README-CircuitPython-Example.md
+++ b/litex/README-CircuitPython-Example.md
@@ -5,6 +5,24 @@
 > Note there is currently a potential Yosys bug that effects building LiteX SoCs. Please use an earlier build of yosys (Before Jul 1st). You can also find prebuilt binaries on the prebuilt branch: https://github.com/gregdavill/OrangeCrab-examples/blob/prebuilt/litex
 
 
+## Setup Instructions
+Before building the LiteX SoC, you must install a suitable toolchain, for example GCC.
+Download a package from [sifive.com/software](https://www.sifive.com/software), extract it, and add it to your path.
+The example below will install GCC v8.3.0 on an Ubuntu system.
+
+```console
+$ curl -LO "https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2020.04.0-x86_64-linux-ubuntu14.tar.gz"
+$ tar -xvf riscv64-unknown-elf-gcc-8.3.0-2020.04.0-x86_64-linux-ubuntu14.tar.gz
+$ export PATH="$(readlink -f ./riscv64-unknown-elf-gcc-8.3.0-2020.04.0-x86_64-linux-ubuntu14/bin):${PATH}"
+$ riscv64-unknown-elf-gcc -v
+```
+
+It is also necessary to install the `pythondata-software-compiler_rt` python package, as follows:
+
+```console
+$ pip install --upgrade git+https://github.com/litex-hub/pythondata-software-compiler_rt.git
+```
+
 ## Build Instructions
 > Add \``--revision 0.1`\` argument when running this to build for the r0.1 board
 ```console

--- a/litex/README-CircuitPython-Example.md
+++ b/litex/README-CircuitPython-Example.md
@@ -52,7 +52,7 @@ $ dfu-util -D combine.dfu
 
 ## CircuitPython is now running!
 
-If you run dmesg, you shloud see a new ttyACM0 attached, as well as a Mass storage device
+The SoC will take a few seconds to start up, but if you run dmesg, you should see a new ttyACM0 attached, as well as a Mass storage device
 ```console
 $ dmesg
 [3660.128564] usb 1-1: new full-speed USB device number 85 using xhci_hcd

--- a/litex/SoC-CircuitPython.py
+++ b/litex/SoC-CircuitPython.py
@@ -302,6 +302,9 @@ class BaseSoC(SoCCore):
 
         self.constants["FLASH_BOOT_ADDRESS"] = self.mem_map['spiflash'] + 0x00100000
 
+        # drive PROGRAMN high
+        self.comb += platform.request('rst_n').eq(1)
+
     # Generate the CSR for the USB
     def write_usb_csr(self, directory):
         csrs = self.usb0.get_csr()


### PR DESCRIPTION
Hi Greg,

Thanks for all your work on this project - it's been really great so far.

While trying out the LiteX example, I tripped at the toolchain step, and needed to install the following:
- `riscv64-unknown-elf-*`
- `pythondata-software-compiler_rt`

I've progressed it to a point, but I'm now bumping into the following issue (maybe due to an issue in my setup?)

```console
$ python SoC-CircuitPython.py
[...]
  converting $_DFF_P_ cell $auto$simplemap.cc:420:simplemap_dff$41417 to $_DFFE_PP_ for $flatten\VexRiscv.$0\_zz_115_[31:0] [28] -> \VexRiscv._zz_115_ [28].
  converting $_DFF_P_ cell $auto$simplemap.cc:420:simplemap_dff$41418 to $_DFFE_PP_ for $flatten\VexRiscv.$0\_zz_115_[31:0] [29] -> \VexRiscv._zz_115_ [29].
  converting $_DFF_P_ cell $auto$simplemap.cc:420:simplemap_dff$41419 to $_DFFE_PP_ for $flatten\VexRiscv.$0\_zz_115_[31:0] [30] -> \VexRiscv._zz_115_ [30].
  converting $_DFF_P_ cell $auto$simplemap.cc:420:simplemap_dff$41420 to $_DFFE_PP_ for $flatten\VexRiscv.$0\_zz_115_[31:0] [31] -> \VexRiscv._zz_115_ [31].

4.39. Executing DFFLEGALIZE pass (convert FFs to types supported by the target).
ERROR: Conflicting init values for signal 1'0 (\soc_basesoc_interface_adr [5] = 1'x != 1'0).
Traceback (most recent call last):
  File "SoC-CircuitPython.py", line 369, in <module>
    main()
  File "SoC-CircuitPython.py", line 345, in main
    vns = builder.build(**builder_kargs)
  File "/home/attie/proj/orange_crab/OrangeCrab-examples/litex/deps/litex/litex/soc/integration/builder.py", line 205, in build
    vns = self.soc.build(build_dir=self.gateware_dir, **kwargs)
  File "/home/attie/proj/orange_crab/OrangeCrab-examples/litex/deps/litex/litex/soc/integration/soc.py", line 923, in build
    return self.platform.build(self, *args, **kwargs)
  File "/home/attie/proj/orange_crab/OrangeCrab-examples/litex/deps/litex/litex/build/lattice/platform.py", line 34, in build
    return self.toolchain.build(self, *args, **kwargs)
  File "/home/attie/proj/orange_crab/OrangeCrab-examples/litex/deps/litex/litex/build/lattice/trellis.py", line 227, in build
    _run_script(script)
  File "/home/attie/proj/orange_crab/OrangeCrab-examples/litex/deps/litex/litex/build/lattice/trellis.py", line 159, in _run_script
    raise OSError("Subprocess failed")
OSError: Subprocess failed
```

I've had a little dig, and it looks like it's the `yosys -l orangecrab.rpt orangecrab.ys` command in the generated `./build/orangecrab/gateware/build_orangecrab.sh` that is failing - returns `1` with the following message:

```
4.39. Executing DFFLEGALIZE pass (convert FFs to types supported by the target).
ERROR: Conflicting init values for signal 1'0 (\soc_basesoc_interface_adr [5] = 1'x != 1'0).
```

Any suggestions would be grately appreciated.

Attie