### PR TITLE
Verilog: blink_reset: fix rst_n pin name (r0.2)

### DIFF
--- a/verilog/blink_reset/blink.v
+++ b/verilog/blink_reset/blink.v
@@ -12,7 +12,7 @@ module top (
     output rgb_led0_g,
     output rgb_led0_b,
 
-    output rsn_n,
+    output rst_n,
     input usr_btn
 );
     // Create a 27 bit register
@@ -34,7 +34,7 @@ module top (
     always @(posedge clk48) begin
         reset_sr <= {usr_btn};
     end
-    assign rsn_n = reset_sr;
+    assign rst_n = reset_sr;
 
 
 endmodule


### PR DESCRIPTION
`blink.v` had the input pin named `rsn_n`, but `rst_n` is what is described in `orangecrab_r0.2.pcf`

It took me an embarrassingly long amount of time to realize `rsn_n` != `rst_n`. My eyes just didn't want to believe they weren't the same thing! 😂