### PR TITLE
Verilog: blink_reset: Add Windows Makefile Support

### DIFF
--- a/verilog/blink_reset/Makefile
+++ b/verilog/blink_reset/Makefile
@@ -3,6 +3,25 @@ PROJ=blink
 # `r0.1` or `r0.2`
 VERSION:=r0.2
 
+# Add Windows and Unix support
+RM         = rm -rf
+COPY       = cp -a
+PATH_SEP   = /
+ifeq ($(OS),Windows_NT)
+# When SHELL=sh.exe and this actually exists, make will silently
+# switch to using that instead of cmd.exe.  Unfortunately, there's
+# no way to tell which environment we're running under without either
+# (1) printing out an error message, or (2) finding something that
+# works everywhere.
+# As a result, we force the shell to be cmd.exe, so it works both
+# under cygwin and normal Windows.
+SHELL      = cmd.exe
+COPY       = copy
+RM         = del
+PATH_SEP   = \\
+endif
+
+
 all: ${PROJ}.dfu
 
 dfu: ${PROJ}.dfu
@@ -19,10 +38,10 @@ dfu: ${PROJ}.dfu
 	ecppack --compress --freq 38.8 --input $< --bit $@
 
 %.dfu : %.bit
-	cp $< $@
+	$(COPY) $< $@
 	dfu-suffix -v 1209 -p 5af0 -a $@
 
 clean:
-	rm -f ${PROJ}.svf ${PROJ}.bit ${PROJ}.config ${PROJ}.json ${PROJ}.dfu 
+	$(RM) -f ${PROJ}.svf ${PROJ}.bit ${PROJ}.config ${PROJ}.json ${PROJ}.dfu 
 
 .PHONY: prog clean


### PR DESCRIPTION
As per `verilog\blink`.