### PR TITLE
Update litex references

### DIFF
--- a/litex/modules/io_block.py
+++ b/litex/modules/io_block.py
@@ -3,7 +3,7 @@
 
 from migen import *
 
-from litex.soc.interconnect.csr import AutoCSR, CSRStorage, CSRField, CSRStatus
+from litex.soc.interconnect.csr import AutoCSR, CSRStorage, CSRField, CSRStatus, CSRAccess
 from migen.genlib.cdc import MultiReg
 
 def io_pins():
@@ -42,21 +42,27 @@ class IOPort(Module, AutoCSR):
     def __init__(self, pads):
         self.alt_fields = ["csr_control"]
 
-        
         pins  = [0,1,5,6,9,10,11,12,13,18,19,20,21]
         nbits = len(pins)
         fields= []
+        fields_read = []
 
 
         for n in pins:
             fields += [
-                CSRField(f"io{n}", 1, n ,description=f"Control for I/O pin {n}"),
+                CSRField(f"io{n}", 1, n ,description=f"Control for I/O pin {n}", access=CSRAccess.ReadWrite),
             ]
+        for n in pins:
+            fields_read += [
+                CSRField(f"io{n}", 1, n ,description=f"Control for I/O pin {n}", access=CSRAccess.ReadOnly),
+            ]
+
+
 
         self._oe  = CSRStorage(nbits, description="""GPIO Tristate(s) Control.
         Write ``1`` enable output driver""", fields=fields)
         self._in  = CSRStatus(nbits,  description="""GPIO Input(s) Status.
-        Input value of IO pad as read by the FPGA""", fields=fields)
+        Input value of IO pad as read by the FPGA""", fields=fields_read)
         self._out = CSRStorage(nbits, description="""GPIO Ouptut(s) Control.
         Value loaded into the output driver""", fields=fields)
 


### PR DESCRIPTION
Fixes #32 for compilation with latest litex  (still needs testing in physical hardware).

Output seems reasonable, everything finishes and the linker script looks like:

```
MEMORY {
	rom : ORIGIN = 0x00000000, LENGTH = 0x00020000
	sram : ORIGIN = 0x10000000, LENGTH = 0x00002000
	main_ram : ORIGIN = 0x40000000, LENGTH = 0x08000000
	spiflash : ORIGIN = 0x20000000, LENGTH = 0x01000000
	usb : ORIGIN = 0x90000000, LENGTH = 0x00001000
	csr : ORIGIN = 0xf0000000, LENGTH = 0x00010000
}
```

and mem.h:

```
//--------------------------------------------------------------------------------
// Auto-generated by LiteX (afcf78f6) on 2024-02-11 21:28:50
//--------------------------------------------------------------------------------
#ifndef __GENERATED_MEM_H
#define __GENERATED_MEM_H

#ifndef ROM_BASE
#define ROM_BASE 0x00000000L
#define ROM_SIZE 0x00020000
#endif

#ifndef SRAM_BASE
#define SRAM_BASE 0x10000000L
#define SRAM_SIZE 0x00002000
#endif

#ifndef MAIN_RAM_BASE
#define MAIN_RAM_BASE 0x40000000L
#define MAIN_RAM_SIZE 0x08000000
#endif

#ifndef SPIFLASH_BASE
#define SPIFLASH_BASE 0x20000000L
#define SPIFLASH_SIZE 0x01000000
#endif

#ifndef USB_BASE
#define USB_BASE 0x90000000L
#define USB_SIZE 0x00001000
#endif

#ifndef CSR_BASE
#define CSR_BASE 0xf0000000L
#define CSR_SIZE 0x00010000
#endif

#ifndef MEM_REGIONS
#define MEM_REGIONS "ROM       0x00000000 0x20000 \nSRAM      0x10000000 0x2000 \nMAIN_RAM  0x40000000 0x8000000 \nSPIFLASH  0x20000000 0x1000000 \nUSB       0x90000000 0x1000 \nCSR       0xf0000000 0x10000 "
#endif
#endif

```