### PR TITLE
Add 85F support for riscv/blink and riscv/button

### DIFF
--- a/50-orangecrab.rules
+++ b/50-orangecrab.rules
@@ -12,7 +12,12 @@
 # After this file is installed, physically unplug and reconnect the
 # orangecrab device.
 #
+
+# OrangeCrab 85F (1209:5af0)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="5af0", GROUP="plugdev", MODE="0666"
+
+# OrangeCrab 25F (1209:5bf2)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="5bf2", GROUP="plugdev", MODE="0666"
 
 # This file is derived from the Teensy UDEV rules
 # http://www.pjrc.com/teensy/49-teensy.rules

--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ $ sudo cp 50-orangecrab.rules /etc/udev/rules.d/50-orangecrab.rules
 ```
 
 After this file is installed, physically unplug and reconnect the orangecrab device.
+
+## RISC-V Cross Compiler Toolchain
+
+To cross-compile for the bootloader's VexRiscv rv32i processor, you need a RISC-V compiler toolchain that includes support libraries for rv32i. Debian and Ubuntu currently have riscv64-unknown-elf compilers that will cross-compile for rv32i. But, to use those, you would need to build your own support libraries (libc, etc). For a ready-to-use option, you can download an embedded RISC-V toolchain from Embecosm's [Tool Chain Downloads](https://www.embecosm.com/resources/tool-chain-downloads/#riscv-stable) page.

--- a/riscv/blink/Makefile
+++ b/riscv/blink/Makefile
@@ -1,5 +1,5 @@
 
-CROSS=riscv64-unknown-elf-
+CROSS=riscv32-unknown-elf-
 CFLAGS=
 
 all: blink_fw.dfu
@@ -8,8 +8,9 @@ all: blink_fw.dfu
 dfu: blink_fw.dfu
 	dfu-util -D blink_fw.dfu
 
+# gcc13 needs -march=rv32i_zicsr (the old way was just -march=rv32i)
 blink_fw.elf: start.s main.c
-	$(CROSS)gcc $(CFLAGS) -march=rv32i -mabi=ilp32 -Wl,-Bstatic,-T,sections.ld,--strip-debug -ffreestanding -nostdlib -I. -o blink_fw.elf start.s main.c
+	$(CROSS)gcc $(CFLAGS) -march=rv32i_zicsr -mabi=ilp32 -Wl,-Bstatic,-T,sections.ld,--strip-debug -ffreestanding -nostdlib -I. -o blink_fw.elf start.s main.c
 
 blink_fw.hex: blink_fw.elf
 	$(CROSS)objcopy -O verilog blink_fw.elf blink_fw.hex
@@ -21,9 +22,17 @@ blink_fw.dfu: blink_fw.bin
 	cp blink_fw.bin blink_fw.dfu
 	dfu-suffix -v 1209 -p 5bf0 -a blink_fw.dfu
 
+# ---- 85F Target ----
+dfu_85F: blink_85F.dfu
+	dfu-util -d 1209:5af0 --alt 0 -D blink_85F.dfu | perl -ne 'print if $$n++>5'
+
+blink_85F.dfu: blink_fw.bin
+	cp blink_fw.bin blink_85F.dfu
+	dfu-suffix -v 1209 -p 5af0 -a blink_85F.dfu 2>&1 | perl -ne 'print if $$n++>5'
+
 # ---- Clean ----
 
 clean:
-	rm -f blink_fw.bin blink_fw.elf blink_fw.dfu
+	rm -f blink_fw.bin blink_fw.elf blink_fw.dfu blink_85F.dfu
 
 .PHONY: all

--- a/riscv/blink/README.md
+++ b/riscv/blink/README.md
@@ -1,7 +1,37 @@
 # riscv.blink
 It blinks the LED
 
-## Building & Loading
+
+## Dependencies
+
+Assuming you are using Ubuntu or Debian Linux, you will need:
+
+1. `riscv-unknown-elf` cross compiler (see [../../README.md](../../README.md))
+
+2. udev rule allowing read and write permissions for your OrangeCrab 25F or
+   85F (see [../../README.md](../../README.md))
+
+3. `dfu-util` (you can install with `sudo apt install dfu-util`)
+
+
+## Building & Loading for OrangeCrab 85F with gcc 13
+
+1. Generate a riscv binary and create a dfu update image:
+   ```console
+   $ make blink_85F.dfu
+   ```
+2. Make sure the OrangeCrab 85F is in DFU mode by plugging in the USB cable
+   while holding down the button. You can check for a DFU device with `lsusb`
+   or `dmseg`. You may need to add a udev rule to give the `plugdev` group
+   permissions for `1209:5af0` if you have not already done so. You also need
+   to have `dfu-util` installed (e.g. `sudo apt install dfu-util`).
+
+3. Load the new firmware into the `-d 1209:5af0 --alt 0` DFU device with
+   ```console
+   $ make dfu_85F
+   ```
+
+## Building & Loading for OrangeCrab 25F
 1. Generate a riscv binary and create a dfu update image.
 ```console
 $ make all

--- a/riscv/button/Makefile
+++ b/riscv/button/Makefile
@@ -1,5 +1,5 @@
 
-CROSS=riscv64-unknown-elf-
+CROSS=riscv32-unknown-elf-
 CFLAGS=
 
 all: blink_fw.dfu
@@ -8,8 +8,9 @@ all: blink_fw.dfu
 dfu: blink_fw.dfu
 	dfu-util -D blink_fw.dfu
 
+# gcc13 needs -march=rv32i_zicsr (the old way was just -march=rv32i)
 blink_fw.elf: start.s main.c
-	$(CROSS)gcc $(CFLAGS) -march=rv32i -mabi=ilp32 -Wl,-Bstatic,-T,sections.ld,--strip-debug -ffreestanding -nostdlib -I. -o blink_fw.elf start.s main.c
+	$(CROSS)gcc $(CFLAGS) -march=rv32i_zicsr -mabi=ilp32 -Wl,-Bstatic,-T,sections.ld,--strip-debug -ffreestanding -nostdlib -I. -o blink_fw.elf start.s main.c
 
 blink_fw.hex: blink_fw.elf
 	$(CROSS)objcopy -O verilog blink_fw.elf blink_fw.hex
@@ -21,9 +22,17 @@ blink_fw.dfu: blink_fw.bin
 	cp blink_fw.bin blink_fw.dfu
 	dfu-suffix -v 1209 -p 5bf0 -a blink_fw.dfu
 
+# ---- 85F Target ----
+dfu_85F: button_85F.dfu
+	dfu-util -d 1209:5af0 --alt 0 -D button_85F.dfu | perl -ne 'print if $$n++>5'
+
+button_85F.dfu: blink_fw.bin
+	cp blink_fw.bin button_85F.dfu
+	dfu-suffix -v 1209 -p 5af0 -a button_85F.dfu 2>&1 | perl -ne 'print if $$n++>5'
+
 # ---- Clean ----
 
 clean:
-	rm -f blink_fw.bin blink_fw.elf blink_fw.dfu
+	rm -f blink_fw.bin blink_fw.elf blink_fw.dfu button_85F.dfu
 
 .PHONY: all

--- a/riscv/button/README.md
+++ b/riscv/button/README.md
@@ -26,7 +26,7 @@ Assuming you are using Ubuntu or Debian Linux, you will need:
    permissions for `1209:5af0` if you have not already done so. You also need
    to have `dfu-util` installed (e.g. `sudo apt install dfu-util`).
 
-3. Load the new firmware into the `-d 1209:5af0 --alt=0` DFU device with
+3. Load the new firmware into the `-d 1209:5af0 --alt 0` DFU device with
    ```console
    $ make dfu_85F
    ```

--- a/riscv/button/README.md
+++ b/riscv/button/README.md
@@ -1,7 +1,37 @@
 # riscv.button
 Read input from button, toggle through colours on the LED
 
-## Building & Loading
+
+## Dependencies
+
+Assuming you are using Ubuntu or Debian Linux, you will need:
+
+1. `riscv-unknown-elf` cross compiler (see [../../README.md](../../README.md))
+
+2. udev rule allowing read and write permissions for your OrangeCrab 25F or
+   85F (see [../../README.md](../../README.md))
+
+3. `dfu-util` (you can install with `sudo apt install dfu-util`)
+
+
+## Building & Loading for OrangeCrab 85F with gcc 13
+
+1. Generate a riscv binary and create a dfu update image:
+   ```console
+   $ make button_85F.dfu
+   ```
+2. Make sure the OrangeCrab 85F is in DFU mode by plugging in the USB cable
+   while holding down the button. You can check for a DFU device with `lsusb`
+   or `dmseg`. You may need to add a udev rule to give the `plugdev` group
+   permissions for `1209:5af0` if you have not already done so. You also need
+   to have `dfu-util` installed (e.g. `sudo apt install dfu-util`).
+
+3. Load the new firmware into the `-d 1209:5af0 --alt=0` DFU device with
+   ```console
+   $ make dfu_85F
+   ```
+
+## Building & Loading for OrangeCrab 25F
 1. Generate a riscv binary and create a dfu update image.
 ```console
 $ make all


### PR DESCRIPTION
This PR has the Makefile changes I needed to get the `riscv/blink` and `riscv/button` examples working with the OrangeCrab r0.2.1 85F that I recently purchased. There are also some README edits.

I tried to avoid changes to the existing example code that appeared to be written for OrangeCrab 25F. But, I'm not sure whether or not that stuff still works as I don't have a 25F board to test with.

The main changes are:
1. Edit main README to suggest using a prebuilt RISC-V embedded toolchain from [Embecosm](https://www.embecosm.com/resources/tool-chain-downloads/#riscv-stable)
2. Edit the udev rules file to include rules for both the 25F and 85F, with comments noting which is which
3. Add Makefile targets to allow for building .dfu files with the `dfu-suffix` for `1209:5af0` (85F)
4. Change `CROSS=...` to work with Embecosm's `riscv32-unknown-elf-gcc`
5. Change `-march=rv32i` to `-march=rv32i_zicsr` so it will work with gcc 13
6. Make the `dfu-util` invocations for 85F make targets more robust (add `-d ...` and `--alt ...` arguments)

Related issue: #21 85F Compatibility